### PR TITLE
Allow skipping the redirect if specified

### DIFF
--- a/lib/local-subdomain/filters/local_subdomain.rb
+++ b/lib/local-subdomain/filters/local_subdomain.rb
@@ -7,6 +7,7 @@ module LocalSubdomain
 
   def redirect_to_lvh_me
     return unless Rails.env.development?
+    return if respond_to?(:skip_redirect?) && skip_redirect?
 
     redirect_domain = ENV['SERVER_REDIRECT_DOMAIN'] || 'lvh.me'
 


### PR DESCRIPTION
Since lvh.me won't work if testing on a mobile device, I thought it would be good to allow a custom skip redirect function that could be implemented by a controller. That would allow a solution like this using xip.io for mobile to work in tandem with lvh: http://stackoverflow.com/questions/23137903/access-local-site-with-subdomain-on-iphone

For my case, I am using the 'browser' gem to find if it's a mobile device and skip_redirect? would return true in that case.
