### PR TITLE
Fix for ArgumentError exception in Ruby 3.0

### DIFF
--- a/lib/local-subdomain/rack/handler.rb
+++ b/lib/local-subdomain/rack/handler.rb
@@ -19,7 +19,7 @@ module Rack
             message(options[:Port])
             options.merge!(Host: '0.0.0.0')
           end
-          orig_run(app, options)
+          orig_run(app, **options)
         end
 
         def self.message(port)


### PR DESCRIPTION
When trying to use the gem with Ruby 3.0.4 the code throws ArgumentError exception.

This fixes is following the [Ruby 3 Docs](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) on the issue.

Here is a partial trace
```
 wrong number of arguments (given 2, expected 1) (ArgumentError)
	from .../vendor/bundle/ruby/3.0.0/gems/local-subdomain-1.0.2/lib/local-subdomain/rack/handler.rb:22:in `run'
```